### PR TITLE
clippy: mostly docs, &Vec and { foo: foo }

### DIFF
--- a/src/agc.rs
+++ b/src/agc.rs
@@ -48,7 +48,7 @@ impl_sampletype!(f64, 1.0);
 ///
 /// This is a fairly simple and slow implementation which is not suitable for
 /// high data rates.
-pub fn agc<T: SampleType>(x: &Vec<T>, a: f32, r: f32) -> f32 {
+pub fn agc<T: SampleType>(x: &[T], a: f32, r: f32) -> f32 {
     let avg = x.iter().fold(0.0_f32, |s, v| s + v.power()) / x.len() as f32;
     let err = 10.0 * r.log10() - 10.0 * avg.log10();
     a * err

--- a/src/cic.rs
+++ b/src/cic.rs
@@ -11,7 +11,7 @@ pub trait SampleType: Copy {
     fn from_out(out: Self::RegType, gain_shift: usize) -> Self;
 }
 
-/// Implement SampleType for scalars like i16.
+/// Implement `SampleType` for scalars like i16.
 /// $t is the sample type, $tt the register type,
 /// $bw_t the bit width of type t, and $bw_tt the bit width of $tt.
 macro_rules! impl_scalar_sampletype {
@@ -41,7 +41,7 @@ macro_rules! impl_scalar_sampletype {
     }
 }
 
-/// Implement SampleType for complex samples like Complex<i16>.
+/// Implement `SampleType` for complex samples like `Complex<i16>`.
 /// $t is the sample type, $tt the register type,
 /// $bw_t the bit width of type t, and $bw_tt the bit width of $tt.
 macro_rules! impl_complex_sampletype {
@@ -124,12 +124,12 @@ impl <T: SampleType> CIC<T> {
         // Compute the filter gain, Q**R, as an equivalent bit shift
         let gain_shift: usize = (q as f32 * (r as f32).log2()).ceil() as usize;
 
-        CIC { q: q, r: r, intg: intg, comb: comb, gain_shift: gain_shift }
+        CIC { q, r, intg, comb, gain_shift }
     }
 
     /// Run the CIC filter over a block x,
     /// returning the filtered and decimated output.
-    pub fn process(&mut self, x: &Vec<T>) -> Vec<T> {
+    pub fn process(&mut self, x: &[T]) -> Vec<T> {
         // Check we were initialised correctly
         assert!(self.q > 0 && self.r > 0);
         assert_eq!(self.intg.len(), self.q);

--- a/src/downconverter.rs
+++ b/src/downconverter.rs
@@ -9,18 +9,19 @@ use super::IQ;
 /// antialias and then decimate by at least 2 afterwards.
 ///
 /// Input block length must be a multiple of 4 for this process.
+#[derive(Default)]
 pub struct RealFs4Downconverter;
 impl RealFs4Downconverter {
     pub fn new() -> RealFs4Downconverter {
         RealFs4Downconverter
     }
 
-    pub fn process(&self, x: &Vec<u16>) -> Vec<IQ<i16>> {
+    pub fn process(&self, x: &[u16]) -> Vec<IQ<i16>> {
         let n = x.len();
         assert_eq!(n % 4, 0);
 
         // Cast input to i16 (we'll clear the sign bit in the loop, in case)
-        let x: &Vec<i16> = unsafe { transmute(x) };
+        let x: &[i16] = unsafe { transmute(x) };
 
         // Allocate output
         let mut y: Vec<IQ<i16>> = Vec::with_capacity(n);

--- a/src/fir.rs
+++ b/src/fir.rs
@@ -3,9 +3,9 @@ use std::f64::consts::PI;
 
 /// Implement the underlying operations and types required by the FIR.
 ///
-/// In general the AccType should be larger than the SampleType but compatible
-/// (i.e. you can add a SampleType to an AccType), while the TapType should
-/// always be scalar and is usually the same size as the AccType.
+/// In general the `AccType` should be larger than the `SampleType` but compatible
+/// (i.e. you can add a `SampleType` to an `AccType`), while the `TapType` should
+/// always be scalar and is usually the same size as the `AccType`.
 ///
 /// gain() specifies the gain of the filter, i.e. the sum of all the taps,
 /// divided by the interpolation level L.
@@ -22,7 +22,7 @@ pub trait SampleType: Copy {
     unsafe fn output(acc: Self::AccType, out: *mut Self, gain: Self::TapType);
 }
 
-/// Implement SampleType for a scalar type such as i16 or f32.
+/// Implement `SampleType` for a scalar type such as i16 or f32.
 /// $t is the sample type, $tt the acc/tap type and $tapsum the filter gain.
 macro_rules! impl_scalar_sampletype {
     ($t:ty, $tt:ty, $tapsum:expr) => {
@@ -52,7 +52,7 @@ macro_rules! impl_scalar_sampletype {
     }
 }
 
-/// Implement SampleType for a Complex type such as Complex<i16>.
+/// Implement `SampleType` for a Complex type such as Complex<i16>.
 /// $t is the sample type, $tt the acc/tap type and $tapsum the filter gain.
 macro_rules! impl_complex_sampletype {
     ($t:ty, $tt:ty, $tapsum:expr) => {
@@ -86,7 +86,7 @@ macro_rules! impl_complex_sampletype {
     }
 }
 
-/// Implement Scalar and Complex SampleTypes for the same underlying types.
+/// Implement Scalar and Complex `SampleTypes` for the same underlying types.
 macro_rules! impl_sampletype {
     ($t:ty, $tt:ty, $tapsum:expr) => {
         impl_scalar_sampletype!($t, $tt, $tapsum);
@@ -122,10 +122,10 @@ impl <T: SampleType> FIR<T> {
     ///
     /// Implements a polyphase FIR to do efficient decimation and interpolation
     /// (identical to a standard FIR when interpolate=1).
-    pub fn new(taps: &Vec<T::TapType>, decimate: usize, interpolate: usize)
+    pub fn new(taps: &[T::TapType], decimate: usize, interpolate: usize)
         -> FIR<T>
     {
-        assert!(taps.len() > 0);
+        assert!(!taps.is_empty());
 
         // Copy the taps and zero-pad to get a multiple of interpolation ratio
         let mut taps: Vec<T::TapType> = taps.to_owned();
@@ -142,9 +142,9 @@ impl <T: SampleType> FIR<T> {
             delay.push(T::AccType::zero());
         }
 
-        FIR { taps: taps, tap_idx: interpolate as isize - 1isize,
-              delay: delay, delay_idx: 0isize, leftover: 0usize,
-              decimate: decimate, interpolate: interpolate }
+        FIR { taps, tap_idx: interpolate as isize - 1isize,
+              delay, delay_idx: 0isize, leftover: 0usize,
+              decimate, interpolate }
     }
 
     /// Create a new FIR from a number of taps, desired frequency response
@@ -152,7 +152,7 @@ impl <T: SampleType> FIR<T> {
     ///
     /// Set decimate=1 for no decimation, decimate=2 for /2, etc.
     /// Set interpolate=1 for no interpolation, interplate=2 for *2, etc.
-    pub fn from_gains(n_taps: usize, gains: &Vec<f64>,
+    pub fn from_gains(n_taps: usize, gains: &[f64],
                       decimate: usize, interpolate: usize)
         -> FIR<T>
     {
@@ -242,7 +242,7 @@ impl <T: SampleType> FIR<T> {
 
     /// Process a block of data x, outputting the filtered and possibly
     /// decimated data.
-    pub fn process(&mut self, x: &Vec<T>) -> Vec<T> {
+    pub fn process(&mut self, x: &[T]) -> Vec<T> {
         // Check we were initialised correctly and
         // ensure invariances required for unsafe code.
         assert!(self.taps.len() % self.interpolate == 0);
@@ -251,8 +251,8 @@ impl <T: SampleType> FIR<T> {
         assert!(self.tap_idx < self.interpolate as isize);
 
         // Quit early if we have an empty input
-        if x.len() == 0 {
-            return vec!{};
+        if x.is_empty() {
+            return Vec::new();
         }
 
         // Allocate output.
@@ -263,12 +263,12 @@ impl <T: SampleType> FIR<T> {
 
         // y might be 0-length, so can't just grab &y[0].
         // Instead do this palaver. out_p from the `else` branch won't be used.
-        let mut out_p: *mut T;
+        let mut out_p: *mut T =
         if ylen > 0 {
-            out_p = &mut y[0] as *mut T;
+            &mut y[0] as *mut T
         } else {
-            out_p = &mut vec!{x[0]}[0] as *mut T;
-        }
+            &mut vec!{x[0]}[0] as *mut T
+        };
 
         // Grab pointers to, and local copies of, various things
         let decimate = self.decimate as isize;
@@ -364,10 +364,10 @@ impl <T: SampleType> FIR<T> {
 
 /// Design an FIR filter using the window method.
 ///
-/// n_taps: the number of taps to return
-/// gains: desired frequency response evalulated on a 512-point grid between
+/// `n_taps`: the number of taps to return
+/// `gains`: desired frequency response evalulated on a 512-point grid between
 ///        zero and the Nyquist frequency
-pub fn firwin2(n_taps: usize, gains: &Vec<f64>) -> Vec<f64> {
+pub fn firwin2(n_taps: usize, gains: &[f64]) -> Vec<f64> {
     assert!(n_taps > 0);
     assert_eq!(gains.len(), 512);
     if n_taps % 2 == 0 {
@@ -395,7 +395,7 @@ pub fn firwin2(n_taps: usize, gains: &Vec<f64>) -> Vec<f64> {
 }
 
 /// Quantise FIR taps to i16 taps that sum to `total`
-pub fn quantise_taps<T: Num + NumCast>(taps: &Vec<f64>, total: T) -> Vec<T> {
+pub fn quantise_taps<T: Num + NumCast>(taps: &[f64], total: T) -> Vec<T> {
     let sum: f64 = taps.iter().fold(0.0_f64, |acc, &x| acc + x);
     let total: f64 = <f64 as NumCast>::from(total).unwrap();
     taps.iter().map(|t| <T as NumCast>::from(t * total / sum).unwrap()).collect()
@@ -409,14 +409,14 @@ fn hamming(n: usize) -> Vec<f64> {
 
 /// Compute the DFT of x.
 #[allow(non_snake_case)]
-fn dft(x: &Vec<Complex<f64>>) -> Vec<Complex<f64>> {
+fn dft(x: &[Complex<f64>]) -> Vec<Complex<f64>> {
     let N = x.len();
     let mut out: Vec<Complex<f64>> = Vec::with_capacity(N);
     for k in 0..N {
         out.push(Complex::new(0.0, 0.0));
         for n in 0..N {
             let f = 2.0 * PI * (k as f64) * (n as f64) / (N as f64);
-            out[k] = out[k] + x[n] * Complex::new(f.cos(), -f.sin());
+            out[k] += x[n] * Complex::new(f.cos(), -f.sin());
         }
     }
     out
@@ -426,16 +426,16 @@ fn dft(x: &Vec<Complex<f64>>) -> Vec<Complex<f64>> {
 ///
 /// IDFT(x) = conj(DFT(conj(x))) / N
 #[allow(non_snake_case)]
-fn idft(x: &Vec<Complex<f64>>) -> Vec<Complex<f64>> {
+fn idft(x: &[Complex<f64>]) -> Vec<Complex<f64>> {
     let N = x.len();
-    let x = x.iter().map(|x| x.conj()).collect();
+    let x: Vec<Complex<f64>> = x.iter().map(|x| x.conj()).collect();
     let y = dft(&x);
-    y.iter().map(|y| y.conj().unscale(N as f64)).collect()
+    y.into_iter().map(|y| y.conj().unscale(N as f64)).collect()
 }
 
 /// Compute the IRDFT of x.
 #[allow(non_snake_case)]
-fn irdft(x: &Vec<Complex<f64>>) -> Vec<f64> {
+fn irdft(x: &[Complex<f64>]) -> Vec<f64> {
     let No2p1 = x.len();
     let No2 = No2p1 - 1;
     let mut xc = x.to_owned();

--- a/src/fm.rs
+++ b/src/fm.rs
@@ -74,6 +74,7 @@ impl_floating_sampletype!(f32);
 impl_floating_sampletype!(f64);
 
 /// FM signal demodulator
+#[derive(Default)]
 pub struct FMDemod<T: SampleType> {
     d: [IQ<T::Reg>; 3]
 }
@@ -82,12 +83,12 @@ impl <T:SampleType> FMDemod<T> {
     /// Create a new FM demodulator
     pub fn new() -> FMDemod<T> {
         let d: [IQ<T::Reg>; 3] = [IQ::new(T::Reg::zero(), T::Reg::zero()); 3];
-        FMDemod{d: d}
+        FMDemod{d }
     }
 
     /// FM demodulate input block x, containing baseband IQ data that has been
     /// frequency modulated. Outputs a block of real-valued samples.
-    pub fn process(&mut self, x: &Vec<IQ<T>>) -> Vec<T> {
+    pub fn process(&mut self, x: &[IQ<T>]) -> Vec<T> {
         let n = x.len();
         let mut d = self.d;
 


### PR DESCRIPTION
`clippy` has some suggestions for the code, most notably changing `&Vec<T>`  to `&[T]` in various places, which allows an array to passed in (as a slice), instead of a `Vec`.

Nothing too offensive. Tests all parse.